### PR TITLE
add release-file hash checking

### DIFF
--- a/lib/control-start-install.js
+++ b/lib/control-start-install.js
@@ -4,6 +4,8 @@ const tar = require('tar');
 const os = require('os');
 const axios = require('axios');
 const crypto = require('crypto');
+const rimraf = require('rimraf');
+const stop = require('./control-stop');
 const downloader = require('./downloader');
 
 const binariesRepo = 'ton-actions/megogo-test';
@@ -34,13 +36,16 @@ function getReleaseHashLocal() {
 
 async function install() {
   if (!fs.existsSync(releaseFilePath) || (getReleaseHashLocal() !== await getReleaseHashRemote())) {
+    if (fs.existsSync(global.appsPath)) {
+      process.stdout.write('New release package detected! Stopping apps and applying updates..\n');
+      await stop();
+      rimraf.sync(global.appsPath);
+    }
+
     process.stdout.write(`Downloading ${releaseUrl}.. `);
     await downloader.getBinaryFile(releaseUrl, cachePath);
     process.stdout.write('Done\n');
-    // todo: Do we need to reset forcibly if the cache has been changed ??
-  }
 
-  if (!fs.existsSync(global.appsPath)) {
     fs.mkdirSync(global.appsPath, { recursive: true });
     process.stdout.write(`Decompressing ${releaseFilePath}.. `);
     await tar.x({ file: releaseFilePath, C: global.appsPath });


### PR DESCRIPTION
If the downloading process has been terminated unexpectedly(even ctrl+c) then we get broken the release archive.
We should ensure that release file hash is equaled to hash of remote release file

closes #54 